### PR TITLE
Closes #16, closes #18

### DIFF
--- a/custom-porn-whitelist.txt
+++ b/custom-porn-whitelist.txt
@@ -1,1 +1,2 @@
+pop.com
 urbandictionary.com

--- a/custom-porn-whitelist.txt
+++ b/custom-porn-whitelist.txt
@@ -1,2 +1,3 @@
+bookmark.com
 pop.com
 urbandictionary.com


### PR DESCRIPTION
Adds bookmark.com and pop.com to custom-porn-whitelist because sites no longer appear to contain porn.  They're business related sites now.